### PR TITLE
Loosen laravel/framework version constraint

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -20,7 +20,7 @@
   },
   "require": {
     "php": ">=5.6.4",
-    "laravel/framework": "5.2.*"
+    "laravel/framework": "^5.2.0"
   },
   "repositories": [
     {


### PR DESCRIPTION
This looks like a great package, I've already pulled it into my own project manually and I'm finding it pretty straightforward to use. But I can't `composer require` it because of the strict `5.2.*` version constraint. I've updated it, and I think this should restrict it to only versions after 5.2, but before any potential future 6.\* versions.

I'm having another issue related to calling `$relation->getKeys($models)` (as shown in the examples for setting the eager constraints). It seems to be trying to call it on the query builder object instead of the `Custom` relation. [Gist](https://gist.github.com/danielmorgan/1ef6ee6b9b7a55129e46b43a3c99698c)

Don't know if this is related to the way I've pulled in the Custom relationship class, or an existing issue, since this is a brand new project. I'd like to try installing it through composer first before trying to debug it further. 
