### PR TITLE
Not work on laravel 5.5 and then fixed. Now it is works

### DIFF
--- a/src/HasCustomRelations.php
+++ b/src/HasCustomRelations.php
@@ -15,11 +15,11 @@ trait HasCustomRelations
      * @param  string  $eagerConstraints
      * @return \App\Services\Database\Relations\Custom
      */
-    public function custom($related, Closure $baseConstraints, Closure $eagerConstraints)
+    public function custom($related, Closure $baseConstraints, Closure $eagerConstraints, $modelKeys, $resultKeys)
     {
         $instance = new $related;
         $query = $instance->newQuery();
 
-        return new Custom($query, $this, $baseConstraints, $eagerConstraints);
+        return new Custom($query, $this, $baseConstraints, $eagerConstraints, $modelKeys, $resultKeys);
     }
 }

--- a/src/HasCustomRelations.php
+++ b/src/HasCustomRelations.php
@@ -15,11 +15,11 @@ trait HasCustomRelations
      * @param  string  $eagerConstraints
      * @return \App\Services\Database\Relations\Custom
      */
-    public function custom($related, Closure $baseConstraints, Closure $eagerConstraints, $modelKeys, $resultKeys)
+    public function custom($related, Closure $baseConstraints, Closure $eagerConstraints, $modelKeys, $resultKeys, $resultIsPlural = true)
     {
         $instance = new $related;
         $query = $instance->newQuery();
 
-        return new Custom($query, $this, $baseConstraints, $eagerConstraints, $modelKeys, $resultKeys);
+        return new Custom($query, $this, $baseConstraints, $eagerConstraints, $modelKeys, $resultKeys, $resultIsPlural);
     }
 }

--- a/src/Relations/Custom.php
+++ b/src/Relations/Custom.php
@@ -42,7 +42,9 @@ class Custom extends Relation
      * @return void
      */
 
-    public function __construct(Builder $query, Model $parent, Closure $baseConstraints, Closure $eagerConstraints, $modelKeys, $resultKeys)
+     protected $resultIsPlural;
+
+    public function __construct(Builder $query, Model $parent, Closure $baseConstraints, Closure $eagerConstraints, $modelKeys, $resultKeys, $resultIsPlural = true)
     {
         $this->baseConstraints = $baseConstraints;
         $this->eagerConstraints = $eagerConstraints;
@@ -118,6 +120,10 @@ class Custom extends Relation
             if (isset($dictionary[$key])) {
                
                 $collection = $this->related->newCollection($dictionary[$key]);
+
+                if( !$this->resultIsPlural ) {
+                    $collection = $collection->first();
+                }
                 $model->setRelation($relation, $collection);
             }
         }


### PR DESCRIPTION
Below is example.

    public function permissions()
    {
        return $this->custom(
            Permission::class,

            // add constraints
            function ($relation) {
                $relation->getQuery()
                    // join the pivot table for permission and roles
                    ->join('permission_role', 'permission_role.permission_id', '=', 'permissions.id')
                    // join the pivot table for users and roles
                    ->join('role_user', 'role_user.role_id', '=', 'permission_role.role_id')
                    // for this user
                    ->where('role_user.user_id', $this->id);
            },

            // add eager constraints
            function ($relation, $models) {
                $relation->getQuery()->whereIn('role_user.user_id', $relation->getKeys($models));
            },
            [id], //Model key. Can multiple
            [user_id] //Relationshipt key. Can multiple
        );
    }

I didn't test above code.

Below is my real codes.
It is work good


```
namespace App\Models\User;

use Illuminate\Database\Eloquent\Model;
use LaravelCustomRelation\HasCustomRelations;

class UserToRole extends Model
{
    use HasCustomRelations;

    const TABLE = 'user_roles';
    protected $table = self::TABLE;

    public function profile()
    {
        return $this->custom(
            RoleProfile::class,

            // add constraints
            function ($relation) {
                // dd2($this->id);
                $relation->getQuery()
                    // for this user
                    // ->where(RoleProfile::TABLE.'.role_id', 7);
                    ->where(RoleProfile::TABLE.'.role_id', $this->role_id)
                    ->where(RoleProfile::TABLE.'.user_id', $this->user_id);
            },

            // add eager constraints
            function ($relation, $models) {
                
                $query= $relation->getQuery();

                foreach ($models as $_model) {
                    $query->whereNested( function($query) use($_model) {
                        $query->where('role_id', $_model->role_id);
                        $query->where('user_id', $_model->user_id);

                    }, 'or');
                }
            },
            ['user_id','role_id'],
            ['user_id','role_id']
        );
    }
}
```

UserToRole hasOne RoleProfile with multi unique key(user_id, role_id).
