### PR TITLE
* Eager loading matcher offloaded to caller

### DIFF
--- a/src/HasCustomRelations.php
+++ b/src/HasCustomRelations.php
@@ -8,18 +8,19 @@ use Closure;
 trait HasCustomRelations
 {
     /**
-     * Define a custom relationship.
-     *
-     * @param  string  $related
-     * @param  string  $baseConstraints
-     * @param  string  $eagerConstraints
-     * @return \App\Services\Database\Relations\Custom
-     */
-    public function custom($related, Closure $baseConstraints, Closure $eagerConstraints)
+    * Define a custom relationship.
+    *
+    * @param  string    $related
+    * @param  \Closure  $baseConstraints
+    * @param  \Closure  $eagerConstraints
+    * @param  \Closure  $eagerMatcher
+    * @return \LaravelCustomRelation\Relations\Custom
+    */
+    public function custom($related, Closure $baseConstraints, Closure $eagerConstraints, Closure $eagerMatcher)
     {
         $instance = new $related;
         $query = $instance->newQuery();
 
-        return new Custom($query, $this, $baseConstraints, $eagerConstraints);
+        return new Custom($query, $this, $baseConstraints, $eagerConstraints, $eagerMatcher);
     }
 }


### PR DESCRIPTION
This should address #3 where match() was handled by the custom relation class.

Instead, the responsibility is offloaded to the caller which is responsible for providing a eager loading matcher closure.

Since it is the caller that should know about the keys and should know how to match models, it should be doing the work rather than trying to provide a generic one-size-fits-all matcher.

If there is a common scenario, maybe a default matcher can be provided, but the caller should be allowed to provide its own.